### PR TITLE
ci: fix Dependabot auto-merge and group Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,13 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "ci"
       include: "scope"
-# Trigger Dependabot scan - test workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,12 +108,12 @@ jobs:
 
     - name: Enable auto-merge for patch/minor
       if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-      run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+      run: gh pr merge --auto --squash --repo "$GITHUB_REPOSITORY" "${{ github.event.pull_request.number }}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Comment on major updates
       if: steps.metadata.outputs.update-type == 'version-update:semver-major'
-      run: gh pr comment "${{ github.event.pull_request.number }}" --body "Major version update — requires manual review."
+      run: gh pr comment "${{ github.event.pull_request.number }}" --repo "$GITHUB_REPOSITORY" --body "Major version update — requires manual review."
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Two related fixes to make the Dependabot automation actually work.

### 1. Auto-merge job was silently failing on every Dependabot PR

The `auto-merge-dependabot` job in \`ci.yml\` runs \`gh pr merge\` / \`gh pr comment\` without a checkout. \`gh\` shells out to \`git\` to resolve the current repo and errors:

\`\`\`
failed to run git: fatal: not a git repository (or any of the parent directories): .git
\`\`\`

Visible on run [24663795528](https://github.com/ak2k/siplink/actions/runs/24663795528) (the major-version branch for #44). The minor/patch branch has the same bug — it just fails the same way without surfacing, which is why #69 (grouped Go minor/patch) has been stuck open for weeks.

Fix: pass \`--repo "\$GITHUB_REPOSITORY"\` to both commands. Cleaner than adding a \`checkout@v4\` step for a metadata-only job.

### 2. GitHub Actions updates weren't grouped

\`dependabot.yml\` groups Go modules for minor/patch (one PR covers everything) but leaves GitHub Actions ungrouped — so each action bump was its own PR. Added a matching \`github-actions\` group.

Also dropped the stale \`# Trigger Dependabot scan - test workflow\` trailer comment.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: next Dependabot minor/patch PR auto-merges (or verify manually by waiting for the next grouped github-actions PR)
- [ ] After merge: grouped github-actions PR appears on next Monday 10:00 scan instead of per-action PRs