### PR TITLE
ci: merge Dependabot PRs directly instead of via --auto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     name: Auto-merge Dependabot
     needs: [nix-build, go-build]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
     - name: Dependabot metadata
@@ -106,9 +106,9 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Enable auto-merge for patch/minor
+    - name: Merge patch/minor
       if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-      run: gh pr merge --auto --squash --repo "$GITHUB_REPOSITORY" "${{ github.event.pull_request.number }}"
+      run: gh pr merge --squash --delete-branch --repo "$GITHUB_REPOSITORY" "${{ github.event.pull_request.number }}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Follow-up to #72 — that fixed the \`gh pr merge\` / \`gh pr comment\` repo-resolution bug, but uncovered two more issues:

1. \`gh pr merge --auto\` requires branch protection (it needs required status checks to wait on). \`main\` isn't protected, so:
   \`\`\`
   GraphQL: Pull request Protected branch rules not configured for this branch (enablePullRequestAutoMerge)
   \`\`\`
   Since \`auto-merge-dependabot\` already has \`needs: [nix-build, go-build]\`, CI has passed by the time the job runs — merge directly, no \`--auto\` needed.

2. Job guard used \`github.actor == 'dependabot[bot]'\`. When the \`Fix vendorHash on failure\` step pushes a commit, the next run's \`github.actor\` is \`github-actions[bot]\` and the guard skips the merge. The PR author (\`pull_request.user.login\`) is stable across intermediate pushes.

Also added \`--delete-branch\` so dependabot branches tidy themselves up.

Visible on the [failing run](https://github.com/ak2k/siplink/actions/runs/24664231458/job/72117756542) from #69's recreate.

## Test plan

- [ ] CI passes here
- [ ] Recreate #69 post-merge; confirm it auto-merges cleanly