### PR TITLE
ci: use PAT for create-pull-request so generated PRs get CI

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v8
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.WORKFLOW_PAT }}
         commit-message: "chore(deps): update all dependencies"
         title: "chore(deps): update all dependencies (Go + Nix)"
         body: |


### PR DESCRIPTION
## Summary

PRs opened with `GITHUB_TOKEN` don't trigger workflow runs ([GitHub docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)) — which meant weekly `Dependency Updates` PRs had no CI. The only safety net was the pre-flight `nix build` step inside the creating workflow.

Swap `peter-evans/create-pull-request` to use a fine-grained PAT (`WORKFLOW_PAT`, repo-scoped, contents+PRs write). The checkout step keeps `GITHUB_TOKEN` — peter-evans does its own commit/push with its configured token.

## Test plan

- [ ] CI passes here
- [ ] Manually trigger `Dependency Updates` (`gh workflow run`) after merge; verify the resulting PR has `Nix Build` + `Go Build` checks