### PR TITLE
test: downgrade golang.org/x/sys to exercise Dependabot vendorHash flow

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
             src = ./.;
             goSum = ./go.sum;
 
-            vendorHash = "sha256-WJBvm1odJ7wuhn56sBhMIPe2wR22Owblw/32PNP7CnU=";
+            vendorHash = "sha256-gDp0XFLR/6vQIb/UvMc1MTaOCgtl8aZJpOmq0NulZ0A=";
             
             # Use proxyVendor due to embedded test files in sipgo dependency
             proxyVendor = true;

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,5 @@ require (
 	github.com/gobwas/ws v1.4.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=


### PR DESCRIPTION
## Summary

Temporary downgrade of \`golang.org/x/sys\` from v0.43.0 → v0.40.0, with vendorHash recomputed to match.

Purpose: give Dependabot something to bump on its next daily scan (10:00 UTC). When it opens the bump PR, we get to observe:

1. Does the \`Fix vendorHash on failure\` step in \`ci.yml\` correctly detect the stale hash and commit a fix?
2. Does the subsequent CI run (now with \`github.actor == github-actions[bot]\`) still let the auto-merge-dependabot job run? (Our guard was switched from \`github.actor\` to \`pull_request.user.login\` in #74 specifically to handle this case — now's when it gets tested.)
3. Does the final PR auto-squash-merge?

## Test plan

- [ ] This PR's CI passes (validates the vendorHash recompute)
- [ ] Trigger Dependabot scan after merge (Insights → Dependency graph → Dependabot → "Check for updates")
- [ ] Watch resulting Dependabot bump PR: expect stale-hash CI failure → auto-fix commit → re-run passing → auto-merge