### PR TITLE
ci: auto-tag patch release on Dependabot security merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,23 @@ jobs:
       run: gh pr comment "${{ github.event.pull_request.number }}" --repo "$GITHUB_REPOSITORY" --body "Major version update — requires manual review."
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Auto-tag security update
+      if: (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor') && steps.metadata.outputs.alert-state != ''
+      env:
+        GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+      run: |
+        # Let the squash-merge settle on main
+        sleep 5
+        sha=$(gh api "repos/$GITHUB_REPOSITORY/branches/main" --jq '.commit.sha')
+        last=$(gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" --jq '.[].ref' \
+          | sed 's|^refs/tags/||' \
+          | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+          | sort -V | tail -1)
+        last="${last:-v0.0.0}"
+        IFS=. read -r major minor patch <<< "${last#v}"
+        next="v${major}.${minor}.$((patch+1))"
+        echo "Tagging $sha as $next (prior: $last, alert: ${{ steps.metadata.outputs.alert-state }})"
+        gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
+          -f ref="refs/tags/$next" \
+          -f sha="$sha"


### PR DESCRIPTION
## Summary

When `dependabot/fetch-metadata` reports a non-empty `alert-state` (i.e., the merged PR closes an open security advisory) and the update is patch or minor, push a new patch tag at the freshly-merged main HEAD. The existing `release.yml` fires on `v*.*.*` tag pushes and builds release assets.

Non-security dep bumps continue to merge silently. Major-version updates (security or not) continue to get a "requires manual review" comment.

### Rule mapping

| Event | Merge | Tag? |
|---|---|---|
| Dependabot patch/minor version update | auto | no |
| Dependabot patch/minor security update | auto | **yes, patch bump** |
| Dependabot major (any kind) | manual | no |
| Direct commit to main | n/a | no |

### Why a fine-grained PAT

`gh api` push with `WORKFLOW_PAT` so the tag creation triggers `release.yml`. GITHUB_TOKEN-created refs don't cascade to workflow triggers.

## Test plan

- [ ] CI passes on this PR
- [ ] Next real Dependabot security update cuts a tag + release automatically (no manual verification possible without a real CVE)